### PR TITLE
Temporarily send original errors

### DIFF
--- a/api/slack.js
+++ b/api/slack.js
@@ -21,8 +21,6 @@ exports.handler = async function(event) {
 				throw new HTTPError('Not configured', 501);
 			}
 
-			console.info(event.headers);
-
 			const { postData } = require('./post-data');
 			const { isEmail, isString, isUrl, isTel, validateMessageHeaders } = require('./validation');
 
@@ -87,6 +85,7 @@ exports.handler = async function(event) {
 					}
 				}]
 			};
+
 			const resp = await fetch(process.env.SLACK_WEBHOOK, {
 				method: 'POST',
 				headers: {
@@ -131,7 +130,9 @@ exports.handler = async function(event) {
 				body: JSON.stringify({
 					error: {
 						message: 'An unknown error occured',
-						status: 500
+						status: 500,
+						orig: new Date().getTime() < new Date('2021-02-14T00:00').getTime()
+							? err.message : null,
 					}
 				})
 			};

--- a/api/validation.js
+++ b/api/validation.js
@@ -65,7 +65,7 @@ exports.validateMessageHeaders = ({ headers: {
 		return false;
 	} else if (! isString(algo)) {
 		return false;
-	} else if (Math.abs(new Date(date) - new Date()) > 30000) {
+	} else if (Math.abs(new Date(date).getTime() - new Date().getTime()) > 30000) {
 		// Message is withing a 30 sec window of now
 		return false;
 	} else {
@@ -78,5 +78,4 @@ exports.validateMessageHeaders = ({ headers: {
 			return false;
 		}
 	}
-
 };


### PR DESCRIPTION
Since this does not impact anything but production, need to run this in production :anger:

Built-in expiration of tomorrow though so that error messages are not accessible in the future