### PR TITLE
Update rollup.config.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,13 +4,23 @@ import { rollupImport } from '@shgysk8zer0/rollup-import';
 
 export default {
 	input: 'js/index.js',
+	external: [],
+	onwarn: (warning) => {
+		if (warning.code === 'MISSING_GLOBAL_NAME') {
+			throw new Error(warning.message);
+		} else if (warning.code !== 'CIRCULAR_DEPENDENCY') {
+			console.warn(`(!) ${warning.message}`);
+		}
+	},
 	output: {
 		file: 'js/index.min.js',
 		format: 'iife',
 		sourcemap: true,
+		globals: {},
+		externalLiveBindings: false,
 	},
 	plugins: [
-		rollupImport(),
+		rollupImport('importmap.json'),
 		terser(),
 	],
 };


### PR DESCRIPTION
Fixed Rollup succeeding even on missing globals. Add missing import map, ignore circular dependencies warnings, and throw on missing globals.
